### PR TITLE
Branch naming fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: 'Build and deploy the site'
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixing the CI/CD since `main` is called `master` in this repo